### PR TITLE
Develop

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -478,3 +478,4 @@ the Humanities.
 ..  LocalWords:  definePrefix useNameResolver foons resolveName HD
 ..  LocalWords:  args param TEI glerbl Github reStructuredText readme
 ..  LocalWords:  validator namespace RequireJS subdirectory DOM
+..  LocalWords:  Dubeau Mangalam

--- a/lib/salve/hashstructs.js
+++ b/lib/salve/hashstructs.js
@@ -12,6 +12,11 @@ define(/** @lends module:hashstructs */ function (require, exports, module) {
 var inherit = require("./oop").inherit;
 
 /**
+ * @classdesc The HashBase class provides a base class for the {@link
+ * module:hashstructs~HashSet HashSet} and {@link
+ * module:hashstructs~HashMap HashMap} classes
+ * @param hash_f Uniquely identifying hash
+ * @param initial {Object} TBA
  * @constructor
  */
 function HashBase(hash_f, initial) {
@@ -111,6 +116,10 @@ HashBase.prototype.toArray = function () {
 };
 
 /**
+ * @classdesc TBA
+ * @extends module:hashstructs~HashBase
+ * @param hash_f Uniquely identifying hash
+ * @param initial {Object} TBA
  * @constructor
  */
 function HashSet() {
@@ -123,6 +132,10 @@ HashSet.prototype.add = function (x) {
 };
 
 /**
+ * @classdesc TBA
+ * @extends module:hashstructs~HashBase
+ * @param hash_f Uniquely identifying hash
+ * @param initial {Object} TBA
  * @constructor
  */
 function HashMap (hash_f, initial) {

--- a/lib/salve/name_resolver.js
+++ b/lib/salve/name_resolver.js
@@ -12,6 +12,12 @@ var validate = require("./validate");
 
 var XML1_NAMESPACE = "http://www.w3.org/XML/1998/namespace";
 
+
+/**
+ * TBA
+ * @classdesc TBA
+ * @constructor
+*/
 function NameResolver() {
     this._context_stack = [];
 

--- a/lib/salve/set.js
+++ b/lib/salve/set.js
@@ -9,16 +9,16 @@ define(/** @lends module:set */function (require, exports, module) {
 'use strict';
 
 /**
- * This is a naive implementation of sets. It stores all elements in
+ * @classdesc <p>This is a naive implementation of sets. It stores all elements in
  * an array. All array manipulations are done by searching through the
  * array from start to hit. So when adding a new element to the Set
  * for instance, the add method will scan the whole array, find the
  * element is not there and then add the element at the end of the
  * array. As naive as this implementation is, it has been shown to be
  * faster than {@link module:hashstructs~HashSet HashSet} and when
- * used in the context of this library.
+ * used in the context of this library.</p>
  *
- * Note that Set cannot hold undefined values.
+ * <p>Note that Set cannot hold undefined values.</p>
  *
  * @constructor
  *

--- a/lib/salve/validate.js
+++ b/lib/salve/validate.js
@@ -209,7 +209,8 @@ function makeSingletonConstructor(base) {
 
 var EventSet = Set;
 
-/** Immutable objects modeling XML Expanded Names.
+/**
+ * @classdesc Immutable objects modeling XML Expanded Names.
  * @constructor
  *
  * @param {String} ns The namespace URI.
@@ -220,7 +221,7 @@ function EName(ns, name) {
     this.name = name;
 }
 /**
-     *
+ *
  * @returns {String} A string representing the object.
  */
 EName.prototype.toString = function () {
@@ -242,7 +243,7 @@ function hashHelper(o) { return o.hash(); }
 
 /**
  *
- * This is the base class for all patterns created from the file
+ * @classdesc This is the base class for all patterns created from the file
  * passed to constructTree. These patterns form a JavaScript representation of
  * the simplified RNG tree. The base class implements a leaf in the
  * RNG tree. In other words, it does not itself refer to children
@@ -433,7 +434,8 @@ Pattern.prototype._elementDefinitions = function (memo) {
 };
 
 /**
- * Pattern objects of this class have exactly one child pattern.
+ * @classdesc Pattern objects of this class have exactly one child
+ * pattern.
  *
  * @constructor
  * @private
@@ -494,7 +496,7 @@ PatternOnePattern.prototype._elementDefinitions = function (memo) {
 
 
 /**
- * Pattern objects of this class have exactly two child patterns.
+ * @classdesc Pattern objects of this class have exactly two child patterns.
  *
  * @constructor
  * @private
@@ -586,8 +588,8 @@ PatternTwoPatterns.prototype._elementDefinitions = function (memo) {
 };
 
 /**
- * The fireEvent methods return an array of objects of this class to
- * notify the caller of errors in the file being validated.
+ * @classdesc The fireEvent methods return an array of objects of this
+ * class to notify the caller of errors in the file being validated.
  *
  * @constructor
  *
@@ -640,11 +642,11 @@ ValidationError.prototype.toStringWithNames = function (names) {
 
 
 /**
- * This class serves as a base for all those errors that have only one
+ * @classdesc This class serves as a base for all those errors that have only one
  * name involved.
  *
  * @constructor
- *
+ * @extends module:validate~ValidationError
  * @param {String} msg The error message.
  * @param {module:validate~EName} name The name of the XML entity at stake.
  *
@@ -669,10 +671,10 @@ SingleNameError.prototype.toStringWithNames = function (names) {
 
 
 /**
- * Error returned when an attribute name is invalid.
+ * @classdesc Error returned when an attribute name is invalid.
  *
  * @constructor
- *
+ * @extends module:validate~SingleNameError
  * @param {String} msg The error message.
  * @param {module:validate~EName} name The name of the attribute at stake.
  *
@@ -683,10 +685,10 @@ function AttributeNameError() {
 inherit(AttributeNameError, SingleNameError);
 
 /**
- * Error returned when an attribute value is invalid.
+ * @classdesc Error returned when an attribute value is invalid.
  *
  * @constructor
- *
+ * @extends module:validate~SingleNameError
  * @param {String} msg The error message.
  * @param {module:validate~EName} name The name of the attribute at stake.
  *
@@ -697,10 +699,10 @@ function AttributeValueError() {
 inherit(AttributeValueError, SingleNameError);
 
 /**
- * Error returned when an element is invalid.
+ * @classdesc Error returned when an element is invalid.
  *
  * @constructor
- *
+ * @extends module:validate~SingleNameError
  * @param {String} msg The error message.
  * @param {module:validate~EName} name The name of the element at stake.
  *
@@ -711,10 +713,10 @@ function ElementNameError() {
 inherit(ElementNameError, SingleNameError);
 
 /**
- * Error returned when choice was not satisfied.
+ * @classdesc Error returned when choice was not satisfied.
  *
  * @constructor
- *
+ * @extends module:validate~ValidationError
  * @param {Array.<module:validate~EName>} names_a The name of the first
  * XML entities at stake.
  * @param {Array.<module:validate~EName>} names_b The name of the second
@@ -745,7 +747,7 @@ ChoiceError.prototype.toStringWithNames = function (names) {
 
 
 /**
- * <p>This class modelizes events occurring during parsing. Upon
+ * @classdesc <p>This class modelizes events occurring during parsing. Upon
  * encountering the start of a start tag, an "enterStartTag" event is
  * generated, etc. Event objects are held to be immutable. No
  * precautions have been made to enforce this. Users of these objects
@@ -920,17 +922,17 @@ function eventsToTreeString(evs) {
     return dumpTree(hash);
 }
 
-/** * <p>Roughly speaking each {@link module:validate~Pattern Pattern}
- * object has a corresponding Walker * class that modelizes an object
- * which is able to walk the pattern to
- * which it belongs. So an Element has an ElementWalker and an
- * Attribute has an AttributeWalker. A Walker object responds to
- * parsing events and reports whether the structure represented by
- * these events is valid.</p>
+/**
+ * @classdesc <p>Roughly speaking each {@link module:validate~Pattern
+ * Pattern} object has a corresponding Walker class that modelizes
+ * an object which is able to walk the pattern to which it belongs. So
+ * an Element has an ElementWalker and an Attribute has an
+ * AttributeWalker. A Walker object responds to parsing events and
+ * reports whether the structure represented by these events is
+ * valid.</p>
  *
  * <p>Note that users of this API do not instantiate Walker objects
  * themselves.</p>
- *
  * @constructor
  */
 function Walker() {
@@ -1013,9 +1015,10 @@ Walker.prototype.canEnd = function () {
  * This method ends the Walker processing. It should not see any
  * further events after end is called.
  *
- * @returns {Boolean} <code>false</code> if the walker ended without
- * error. Otherwise, a list of {@link module:validate~ValidationError
- * ValidationError} objects.
+ * @returns {Boolean|Array.<module.validate~ValidationError>}
+ * <code>false</code> if the walker ended without error. Otherwise, a
+ * list of {@link module:validate~ValidationError ValidationError}
+ * objects.
  */
 Walker.prototype.end = function () {
     return false;
@@ -1072,9 +1075,9 @@ Walker.prototype._suppressAttributes = function () {
 };
 
 /**
- * Mixin designed to be used for {@link module:validate~Walker
- * Walkers} that can only have one * subwalker.
- *
+ * @classdesc Mixin designed to be used for {@link module:validate~Walker
+ * Walkers} that can only have one subwalker.
+ * @mixin
  * @constructor
  * @private
  */
@@ -1109,9 +1112,9 @@ SingleSubwalker.prototype.end = function () {
 
 
 /**
- * Mixin designed to be used for {@link module:validate~Walker
+ * @classdesc Mixin designed to be used for {@link module:validate~Walker
  * Walkers} that cannot have any subwalkers.
- *
+ * @mixin
  * @constructor
  * @private
  */
@@ -1134,7 +1137,7 @@ NoSubwalker.prototype.end = function () {
 };
 
 /**
- * Pattern for <code>&lt;empty/></code>.
+ * @classdesc Pattern for <code>&lt;empty/></code>.
  *
  * @constructor
  * @private
@@ -1158,11 +1161,11 @@ addWalker(Empty, EmptyWalker);
 
 
 /**
- * Walker for {@link module:validate~Empty Empty}.
- *
+ * @classdesc Walker for {@link module:validate~Empty Empty}.
+ * @extends module:validate~Walker
+ * @mixes module:validate~NoSubwalker
  * @constructor
  * @private
- * @extends module:validate~Walker
  */
 function EmptyWalker (el) {
     Walker.call(this);
@@ -1202,7 +1205,7 @@ inherit(Value, Pattern);
 addWalker(Value, TextWalker); // Cheat until we have a real Data library.
 
 /**
- * Pattern for <code>&lt;notAllowed/></code>.
+ * @classdesc Pattern for <code>&lt;notAllowed/></code>.
  *
  * @constructor
  * @private
@@ -1213,7 +1216,7 @@ inherit(NotAllowed, Pattern);
 // NotAllowed has no walker.
 
 /**
- * Pattern for <code>&lt;text/></code>.
+ * @classdesc Pattern for <code>&lt;text/></code>.
  *
  * @constructor
  * @private
@@ -1224,6 +1227,14 @@ inherit(Text, Pattern);
 
 addWalker(Text, TextWalker);
 
+/**
+ *
+ * @classdesc Walker for {@link module:validate~Text Text}
+ * @extends module:validate~Walker
+ * @mixes module:validate~NoSubwalker
+ * @private
+ * @constructor
+*/
 function TextWalker (el) {
     Walker.call(this);
     this.possible_cached = new EventSet(TextWalker._text_event);
@@ -1242,6 +1253,14 @@ TextWalker.prototype.fireEvent = function (ev) {
     return  (ev.params.length === 1 && ev.params[0] == "text") ? false:
         undefined;
 };
+
+/**
+ * TBA
+ * @classdesc TBA
+ * @extends module:validate~Pattern
+ * @private
+ * @constructor
+*/
 
 function Ref(xml_path, name) {
     Pattern.call(this, xml_path);
@@ -1277,6 +1296,15 @@ Ref.prototype.newWalker = function () {
     return this.resolves_to.pat.newWalker();
 };
 
+/**
+ *
+ * @classdesc Walker for {@link module:validate~Ref Ref}
+ * @extends module:validate~Walker
+ * @mixes module:validate~SingleSubwalker
+ * @private
+ * @constructor
+*/
+
 function RefWalker(el) {
     Walker.call(this);
     this.el = el;
@@ -1290,6 +1318,14 @@ RefWalker.prototype._copyInto = function (obj, memo) {
     obj.el = this.el;
     obj.subwalker = this.subwalker._clone(memo);
 };
+
+/**
+ * TBA
+ * @classdesc TBA
+ * @extends module:validate~Pattern
+ * @private
+ * @constructor
+*/
 
 function OneOrMore(xml_path, pats) {
     PatternOnePattern.call(this, xml_path);
@@ -1305,6 +1341,14 @@ addWalker(OneOrMore, OneOrMoreWalker);
 OneOrMore.prototype._cleanAttrs = function () {
     return [this.pat, true];
 };
+
+/**
+ *
+ * @classdesc Walker for {@link module:validate~OneOrMore OneOrMore}
+ * @extends module:validate~Walker
+ * @private
+ * @constructor
+*/
 
 function OneOrMoreWalker(el)
 {
@@ -1397,6 +1441,14 @@ OneOrMoreWalker.prototype.end = function () {
     return this.current_iteration.end();
 };
 
+/**
+ * TBA
+ * @classdesc TBA
+ * @extends module:validate~Pattern
+ * @private
+ * @constructor
+*/
+
 function Choice(xml_path, pats) {
     PatternTwoPatterns.call(this, xml_path);
     if (pats !== undefined) {
@@ -1434,6 +1486,13 @@ Choice.prototype._cleanAttrs = function () {
     return [this, cleaned[1]];
 };
 
+/**
+ *
+ * @classdesc Walker for {@link module:validate~Choice Choice}
+ * @extends module:validate~Walker
+ * @private
+ * @constructor
+*/
 
 function ChoiceWalker(el) {
     Walker.call(this);
@@ -1441,7 +1500,7 @@ function ChoiceWalker(el) {
     this.chosen = false;
 
     this.walker_a = this.walker_b = undefined;
-    this.instanciated_walkers = false;
+    this.instantiated_walkers = false;
     this.done = false;
 
 }
@@ -1456,13 +1515,13 @@ ChoiceWalker.prototype._copyInto = function (obj, memo) {
         this.walker_a._clone(memo):undefined;
     obj.walker_b = (this.walker_b !== undefined) ?
         this.walker_b._clone(memo): undefined;
-    obj.instanciated_walkers = this.instanciated_walkers;
+    obj.instantiated_walkers = this.instantiated_walkers;
     obj.done = this.done;
 };
 
-ChoiceWalker.prototype._instanciateWalkers = function () {
-    if (!this.instanciated_walkers) {
-        this.instanciated_walkers = true;
+ChoiceWalker.prototype._instantiateWalkers = function () {
+    if (!this.instantiated_walkers) {
+        this.instantiated_walkers = true;
 
         this.walker_a = this.el.pat_a.newWalker();
         this.walker_b = this.el.pat_b.newWalker();
@@ -1471,7 +1530,7 @@ ChoiceWalker.prototype._instanciateWalkers = function () {
 
 
 ChoiceWalker.prototype._possible = function () {
-    this._instanciateWalkers();
+    this._instantiateWalkers();
     if (this.possible_cached !== undefined)
         return this.possible_cached;
 
@@ -1493,7 +1552,7 @@ ChoiceWalker.prototype.fireEvent = function(ev) {
     if (this.done)
         return undefined;
 
-    this._instanciateWalkers();
+    this._instantiateWalkers();
 
     this.possible_cached = undefined;
     var ret_a = (this.walker_a !== undefined) ?
@@ -1522,7 +1581,7 @@ ChoiceWalker.prototype.fireEvent = function(ev) {
 };
 
 ChoiceWalker.prototype._suppressAttributes = function () {
-    this._instanciateWalkers();
+    this._instantiateWalkers();
     if (!this.suppressed_attributes) {
         this.possible_cached = undefined; // no longer valid
         this.suppressed_attributes = true;
@@ -1535,7 +1594,7 @@ ChoiceWalker.prototype._suppressAttributes = function () {
 };
 
 ChoiceWalker.prototype.canEnd = function () {
-    this._instanciateWalkers();
+    this._instantiateWalkers();
 
     var walker_a_ret = (this.walker_a !== undefined) ?
             this.walker_a.canEnd() : true;
@@ -1553,7 +1612,7 @@ ChoiceWalker.prototype.canEnd = function () {
 ChoiceWalker.prototype.end = function () {
     this.done = true;
 
-    this._instanciateWalkers();
+    this._instantiateWalkers();
 
     if (this.canEnd()) return false;
 
@@ -1601,11 +1660,19 @@ ChoiceWalker.prototype.end = function () {
     return walker_a_ret || walker_b_ret;
 };
 
+
+/**
+ * TBA
+ * @classdesc TBA
+ * @extends module:validate~PatternTwoPatterns
+ * @private
+ * @constructor
+*/
 function Group(xml_path, pats) {
     PatternTwoPatterns.call(this, xml_path);
     if (pats !== undefined) {
         if (pats.length != 2)
-            throw new Error("GroupWalker walk only groups of two elements!");
+            throw new Error("GroupWalkers walk only groups of two elements!");
         this.pat_a = pats[0];
         this.pat_b = pats[1];
     }
@@ -1633,6 +1700,13 @@ Group.prototype._cleanAttrs = function () {
     return [this, cleaned[1]];
 };
 
+/**
+ *
+ * @classdesc Walker for {@link module:validate~Group Group}
+ * @extends module:validate~Walker
+ * @private
+ * @constructor
+*/
 
 function GroupWalker(el) {
     Walker.call(this);
@@ -1657,7 +1731,7 @@ GroupWalker.prototype._copyInto = function (obj, memo) {
         this.walker_b._clone(memo) : undefined;
 };
 
-GroupWalker.prototype._instanciateWalkers = function () {
+GroupWalker.prototype._instantiateWalkers = function () {
     if (this.walker_a === undefined) {
         this.walker_a = this.el.pat_a.newWalker();
         this.walker_b = this.el.pat_b.newWalker();
@@ -1665,7 +1739,7 @@ GroupWalker.prototype._instanciateWalkers = function () {
 };
 
 GroupWalker.prototype._possible = function () {
-    this._instanciateWalkers();
+    this._instantiateWalkers();
     if (this.possible_cached !== undefined)
         return this.possible_cached;
 
@@ -1692,7 +1766,7 @@ GroupWalker.prototype._possible = function () {
 };
 
 GroupWalker.prototype.fireEvent = function(ev) {
-    this._instanciateWalkers();
+    this._instantiateWalkers();
 
     this.possible_cached = undefined;
     if (!this.ended_a) {
@@ -1719,7 +1793,7 @@ GroupWalker.prototype.fireEvent = function(ev) {
 };
 
 GroupWalker.prototype._suppressAttributes = function () {
-    this._instanciateWalkers();
+    this._instantiateWalkers();
     if (!this.suppressed_attributes) {
         this.possible_cached = undefined; // no longer valid
         this.suppressed_attributes = true;
@@ -1730,12 +1804,12 @@ GroupWalker.prototype._suppressAttributes = function () {
 };
 
 GroupWalker.prototype.canEnd = function () {
-    this._instanciateWalkers();
+    this._instantiateWalkers();
     return this.walker_a.canEnd() && this.walker_b.canEnd();
 };
 
 GroupWalker.prototype.end = function () {
-    this._instanciateWalkers();
+    this._instantiateWalkers();
     var ret = this.walker_a.end();
     if (ret)
         return ret;
@@ -1747,6 +1821,13 @@ GroupWalker.prototype.end = function () {
     return false;
 };
 
+/**
+ * TBA
+ * @classdesc TBA
+ * @extends module:validate~PatternOnePattern
+ * @private
+ * @constructor
+*/
 function Attribute(xml_path, name, pats) {
     PatternOnePattern.call(this, xml_path);
     this.name = name;
@@ -1778,6 +1859,13 @@ Attribute.prototype._cleanAttrs = function () {
     return [this, false];
 };
 
+/**
+ *
+ * @classdesc Walker for {@link module:validate~Attribute Attribute}
+ * @extends module:validate~Walker
+ * @private
+ * @constructor
+*/
 function AttributeWalker(el) {
     Walker.call(this);
     this.el = el;
@@ -1861,6 +1949,14 @@ AttributeWalker.prototype.end = function () {
     return false;
 };
 
+/**
+ * TBA
+ * @classdesc TBA
+ * @extends module:validate~PatternOnePattern
+ * @private
+ * @constructor
+*/
+
 function Element(xml_path, name, pats) {
     PatternOnePattern.call(this, xml_path);
     this.name = name;
@@ -1924,6 +2020,14 @@ Element.prototype._elementDefinitions = function (memo) {
     else
         memo[key].push(this);
 };
+
+/**
+ *
+ * @classdesc Walker for {@link module:validate~Element Element}
+ * @extends module:validate~Walker
+ * @private
+ * @constructor
+*/
 
 function ElementWalker(el) {
     Walker.call(this);
@@ -2103,6 +2207,15 @@ ElementWalker.prototype.end = function (ev) {
     return false;
 };
 
+
+/**
+ *
+ * @classdesc TBA
+ * @extends module:validate~Walker
+ * @private
+ * @constructor
+*/
+
 function DisallowedElementWalker(el) {
     Walker.call(this);
     this.el = el;
@@ -2124,7 +2237,13 @@ DisallowedElementWalker.prototype.fireEvent = function (ev) {
     return undefined; // we never match!
 };
 
-
+/**
+ * TBA
+ * @classdesc TBA
+ * @extends module:validate~PatternOnePattern
+ * @private
+ * @constructor
+*/
 
 function Define(xml_path, name, pats) {
     PatternOnePattern.call(this, xml_path);
@@ -2158,6 +2277,15 @@ Define.prototype._prepare = function (namespaces) {
     }
 };
 
+/**
+ *
+ * @classdesc Walker for {@link module:validate~Define Define}
+ * @extends module:validate~Walker
+ * @mixes module:validate~SingleSubwalker
+ * @private
+ * @constructor
+*/
+
 function DefineWalker(el) {
     Walker.call(this);
     this.el = el;
@@ -2173,7 +2301,7 @@ DefineWalker.prototype._copyInto = function (obj, memo) {
 };
 
 /**
- * <p>This is an exception raised to indicate references to
+ * @classdesc <p>This is an exception raised to indicate references to
  * undefined entities in a schema. If for instance element A has
  * element B as its children but B is not defined, then this exception
  * would be raised.</p>
@@ -2182,7 +2310,7 @@ DefineWalker.prototype._copyInto = function (obj, memo) {
  * time this module loads a schema, the schema should have been
  * simplified already and simplification should have failed due to the
  * unresolvable reference.</p>
- *
+ * @extends Error
  * @constructor
  *
  * @param {module:set~Set} references The set of references that could
@@ -2287,6 +2415,15 @@ Grammar.prototype.getNamespaces = function () {
 
 addWalker(Grammar, GrammarWalker);
 
+/**
+ *
+ * @classdesc Walker for {@link module:validate~Grammar Grammar}
+ * @extends module:validate~Walker
+ * @mixes module:validate~SingleSubwalker
+ * @private
+ * @constructor
+*/
+
 function GrammarWalker(el) {
     Walker.call(this);
     this.el = el;
@@ -2334,6 +2471,8 @@ GrammarWalker.prototype.unresolveName = function (uri, name) {
  * @returns {false|Array.<module:validate~ValidationError>} The value
  * <code>false</code> if there is no error or an array of
  * {@link module:validate~ValidationError ValidationError} objects.
+ * @throws {Error} If there is no name resolver available or if the
+ * context cannot be determined for the cause of an undefined value
  */
 GrammarWalker.prototype.fireEvent = function (ev) {
     //


### PR DESCRIPTION
Updated flyspell dictionaries
Added "use strict" where needed
Reduced line lengths to 80 columns or less
Changed from @class/@constructor to @classdesc+@constructor format
added @mixin and @mixes
added @throws for all errors
Checked and corrected values in @returns
Added jsdoc documentation for all classes (using skeletons where uncertain)
