### PR TITLE
Add argument, set actions, update help messages.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -583,10 +583,8 @@ The variables that can be set are:
 |jsdoc                  | jsdoc command to run                                 |
 +-----------------------+------------------------------------------------------+
 |jsdoc_private          | jsdoc should produce documentation for private       |
-|                       | entities. True by default.                           |
-+-----------------------+------------------------------------------------------+
-|no_jsdoc_private       | jsdoc should not produce documentation for private   |
-|                       | entities. False by default.                          |
+|                       | entities. True by default. Set jsdoc_private to      |
+|                       | false using no_jsdoc_private.                        |
 +-----------------------+------------------------------------------------------+
 |jsdoc_required_version | The jsdoc version required by the project's docs     |
 +-----------------------+------------------------------------------------------+

--- a/README.rst
+++ b/README.rst
@@ -585,6 +585,9 @@ The variables that can be set are:
 |jsdoc_private          | jsdoc should produce documentation for private       |
 |                       | entities. True by default.                           |
 +-----------------------+------------------------------------------------------+
+|no_jsdoc_private       | jsdoc should not produce documentation for private   |
+|                       | entities. False by default.                          |
++-----------------------+------------------------------------------------------+
 |jsdoc_required_version | The jsdoc version required by the project's docs     |
 +-----------------------+------------------------------------------------------+
 |jsdoc_template_dir     | Location of the jsdoc default template               |

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -61,17 +61,18 @@ parser.addArgument(['--jsdoc'], {
 });
 
 parser.addArgument(["--jsdoc-private"], {
-    help: "Jsdoc will document private functions.",
+    help: "jsdoc will document private functions.",
     type: Boolean,
     action: 'storeTrue',
     defaultValue: local_config.jsdoc_private
 });
 
 parser.addArgument(["--no-jsdoc-private"], {
-    help: "Jsdoc will not document private functions.",
+    help: "jsdoc will not document private functions.",
     type: Boolean,
     action: 'storeFalse',
-    defaultValue: local_config.jsdoc_private
+    dest: 'jsdoc_private',
+    defaultValue: local_config.no_jsdoc_private
 });
 
 parser.addArgument(["--jsdoc-required-version"], {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -72,7 +72,7 @@ parser.addArgument(["--no-jsdoc-private"], {
     type: Boolean,
     action: 'storeFalse',
     dest: 'jsdoc_private',
-    defaultValue: local_config.no_jsdoc_private
+    defaultValue: local_config.jsdoc_private
 });
 
 parser.addArgument(["--jsdoc-required-version"], {

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -61,8 +61,16 @@ parser.addArgument(['--jsdoc'], {
 });
 
 parser.addArgument(["--jsdoc-private"], {
-    help: "Whether or not jsdoc will document private functions.",
+    help: "Jsdoc will document private functions.",
     type: Boolean,
+    action: 'storeTrue',
+    defaultValue: local_config.jsdoc_private
+});
+
+parser.addArgument(["--no-jsdoc-private"], {
+    help: "Jsdoc will not document private functions.",
+    type: Boolean,
+    action: 'storeFalse',
     defaultValue: local_config.jsdoc_private
 });
 


### PR DESCRIPTION
Resolves issue that salve's gulp does not handle `--jsdoc-private option`.

With this change, either run `gulp gh-pages-build --jsdoc-private` for jsdoc to document private functions, or run `gulp gh-pages-build --no-jsdoc-private` for jsdoc to not document private functions.