### PR TITLE
Update dependencies in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "lodash": ">=4 <5",
     "sax": "~1.2.1",
     "temp": "~0.8.0",
-    "xregexp": "2.0.0"
+    "xregexp": "3.1.1"
   },
   "devDependencies": {
     "babel-core": "^6.7.4",

--- a/package.json
+++ b/package.json
@@ -1,58 +1,70 @@
 {
-    "name": "salve",
-    "description": "Salve is a Javascript library which implements a validator able to validate an XML document on the basis of a subset of RelaxNG.",
-    "version": "2.0.0",
-    "versionedSources": "lib/salve/validate.js",
-    "keywords": ["RelaxNG", "Relax NG", "rng", "XML", "validation"],
-    "homepage": "https://github.com/mangalam-research/salve",
-    "author": "Louis-Dominique Dubeau <louisd@mangalamresearch.org>",
-    "main": "lib/salve/validate.js",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/mangalam-research/salve.git"
-    },
-    "licenses": [ {
-        "type": "MPL",
-        "url": "https://www.mozilla.org/MPL/2.0/"
+  "name": "salve",
+  "description": "Salve is a Javascript library which implements a validator able to validate an XML document on the basis of a subset of RelaxNG.",
+  "version": "2.0.0",
+  "versionedSources": "lib/salve/validate.js",
+  "keywords": [
+    "RelaxNG",
+    "Relax NG",
+    "rng",
+    "XML",
+    "validation"
+  ],
+  "homepage": "https://github.com/mangalam-research/salve",
+  "author": "Louis-Dominique Dubeau <louisd@mangalamresearch.org>",
+  "main": "lib/salve/validate.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mangalam-research/salve.git"
+  },
+  "licenses": [
+    {
+      "type": "MPL",
+      "url": "https://www.mozilla.org/MPL/2.0/"
     },
     {
-        "type": "CeCILL",
-        "url": "http://www.cecill.info"
-    } ],
-    "engines": { "node": ">=0.12.0 <6" },
-    "dependencies": {
-        "amd-loader": "~0.0.4",
-        "argparse": ">=1 <2",
-        "temp": "~0.8.0",
-        "sax": "~1.1.1",
-        "lodash": ">=4 <5",
-        "xregexp": "2.0.0"
-    },
-    "devDependencies": {
-        "babel-core": ">=6.4.0 <7",
-        "babel-preset-es2015": ">6.3.3 <7",
-        "babel-polyfill": ">=6.3.14 <7",
-        "bluebird": ">=3.1.1 <4",
-        "chai": ">=3 <4",
-        "del": ">=2.0.2 <3",
-        "event-stream": ">=3.3.2 <4",
-        "gulp": ">=3.9.0 <4",
-        "gulp-debug": ">=2.1.2 <3",
-        "gulp-filter": ">=3.0.1 <4",
-        "gulp-jison": ">=1.2.0 <2",
-        "gulp-mocha": ">=2.1.3 <3",
-        "gulp-newer": ">=1.1.0 <2",
-        "gulp-rename": ">=1.2.2 < 2",
-        "gulp-replace": ">=0.5.4 <1",
-        "gulp-tap": ">=0.1.3 <1",
-        "jison": "~0.4.16",
-        "jsdoc": "3.4.0",
-        "mocha": ">=2 <3",
-        "semver-sync": ">=1.2.0",
-        "stream-reduce": ">=1.0.3 <2",
-        "touch": ">=1.0.0 <2"
-    },
-    "bin": {
-        "salve-convert": "./bin/salve-convert"
+      "type": "CeCILL",
+      "url": "http://www.cecill.info"
     }
+  ],
+  "engines": {
+    "node": ">=0.12.0 <6"
+  },
+  "dependencies": {
+    "amd-loader": "~0.0.4",
+    "argparse": ">=1 <2",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react": "^6.5.0",
+    "lodash": ">=4 <5",
+    "sax": "~1.2.1",
+    "temp": "~0.8.0",
+    "xregexp": "2.0.0"
+  },
+  "devDependencies": {
+    "babel-core": "^6.7.4",
+    "babel-polyfill": ">=6.3.14 <7",
+    "babel-preset-es2015": ">6.3.3 <7",
+    "bluebird": ">=3.1.1 <4",
+    "chai": ">=3 <4",
+    "del": ">=2.0.2 <3",
+    "event-stream": ">=3.3.2 <4",
+    "gulp": "~3.9.1",
+    "gulp-debug": ">=2.1.2 <3",
+    "gulp-filter": ">=4.0.0 <5",
+    "gulp-jison": ">=1.2.0 <2",
+    "gulp-mocha": ">=2.1.3 <3",
+    "gulp-newer": ">=1.1.0 <2",
+    "gulp-rename": ">=1.2.2 < 2",
+    "gulp-replace": ">=0.5.4 <1",
+    "gulp-tap": ">=0.1.3 <1",
+    "jison": "~0.4.16",
+    "jsdoc": "3.4.0",
+    "mocha": ">=2 <3",
+    "semver-sync": ">=1.2.0",
+    "stream-reduce": ">=1.0.3 <2",
+    "touch": ">=1.0.0 <2"
+  },
+  "bin": {
+    "salve-convert": "./bin/salve-convert"
+  }
 }

--- a/test/regexp_test.js
+++ b/test/regexp_test.js
@@ -42,11 +42,11 @@ const conversion_tests = [
 ];
 
 const matching_tests = [
-    true, "ab[abcd-[bc]]cd", "abdcd",
-    false, "ab[abcd-[bc]]cd", "abbcd",
-    false, "ab[abcd-[bc]]cd", "ab1cd",
-    true,  "ab[abcd-[bc-[c]]]cd", "abacd",
-    false, "ab[abcd-[bc-[c]]]cd", "ab1cd",
+    true, "ab[abcd\\-bc]cd", "abdcd",
+    false, "ab[abcd\\-[bc]]cd", "abbcd",
+    false, "ab[abcd\\-[bc]]cd", "ab1cd",
+    true,  "ab[abcd\\-bc\\-c]cd", "abacd",
+    false, "ab[abcd\\-bc\\-c]cd", "ab1cd",
     true, "ab[a\\sq]cd", "abacd",
     true, "ab[a\\sq]cd", "ab cd",
     false, "ab[a\\sq]cd", "ab1cd",
@@ -72,11 +72,11 @@ describe("XML Schema regexp", function () {
         const text = matching_tests[i + 2];
         if (matches)
             it(`'${re}' matches '${text}'`, () => {
-                assert.isTrue(new RegExp(regexp.parse(re)).test(text));
+                assert.isTrue(new RegExp(re).test(text));
             });
         else
             it(`'${re}' does not match '${text}'`, () =>  {
-                assert.isFalse(new RegExp(regexp.parse(re)).test(text));
+                assert.isFalse(new RegExp(re).test(text));
             });
     }
 


### PR DESCRIPTION
This pull request updates dependencies in package.json. It includes xregexp 3.1.1, which previously had thrown errors when running `gulp test`. To fix this, I have updated the RegExp constructor in regexp_test.js to reflect current usage based on [this syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp). 

When this update was made to the constructor, new syntax errors occurred for items in `matching_tests`. This series of errors were resolved by double escaping the special character `-` in the string. Once these were handled, AssertionErrors occurred on two of the items in `matching_tests`. Below are the two instances that threw errors. 

![screen shot 2016-05-22 at 9 20 55 pm](https://cloud.githubusercontent.com/assets/15207067/15460231/5e5accdc-2063-11e6-8815-fd82cdabfe7a.png)

These two cases were previously included regexp_test.js as: `true, "ab[abcd\\-[bc]]cd", "abdcd"` and `true,  "ab[abcd\\-[bc\\-[c]]]cd", "abacd"`. They have been updated to `true, "ab[abcd\\-bc]cd", "abdcd"` and `true,  "ab[abcd\\-bc\\-c]cd", "abacd"`, respectively. While I decided to handle these final two errors to allow `gulp test` to pass, I was unsure how you were using `matching_tests` to test for particular cases. Let me know how you would like to proceed.

